### PR TITLE
refactor: remove redundant event_name input from workflow call

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,6 @@ jobs:
       packages: write
       security-events: write
     with:
-      event_name: ${{ github.event_name }}
       addon_guid: "{531480d4-0398-499e-bdfc-79e7d6cf0055}"
       xpi_path: "injectooor.zip"
     secrets:


### PR DESCRIPTION
## Summary
Removes redundant \`event_name: \${{ github.event_name }}\` input from the reusable workflow call.

\`github.event_name\` (and \`github.ref_name\`) are available directly in all reusable workflows — they don't need to be passed as inputs. Depends on tehw0lf/workflows#28.