### PR TITLE
fix(ci): add pull-requests: write permission to workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
       packages: write
       security-events: write
+      pull-requests: write
     with:
       addon_guid: "{531480d4-0398-499e-bdfc-79e7d6cf0055}"
       xpi_path: "injectooor.zip"


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` permission to the reusable workflow call

## Reason
All repos using reusable workflows from `tehw0lf/workflows` require `pull-requests: write` to function correctly, regardless of the build tool used.